### PR TITLE
Point Gradle Wrapper to the right jar

### DIFF
--- a/changelog/@unreleased/pr-5.v2.yml
+++ b/changelog/@unreleased/pr-5.v2.yml
@@ -1,5 +1,0 @@
-type: improvement
-improvement:
-  description: Fix Gradle Wrapper settings
-  links:
-  - https://github.com/palantir/gradle-incremental-configuration-cache/pull/5

--- a/changelog/@unreleased/pr-5.v2.yml
+++ b/changelog/@unreleased/pr-5.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix Gradle Wrapper settings
+  links:
+  - https://github.com/palantir/gradle-incremental-configuration-cache/pull/5

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/AllowListFile.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/AllowListFile.java
@@ -24,8 +24,7 @@ import java.util.stream.Collectors;
 import org.gradle.api.GradleException;
 
 
-// TODO: maybe add the file version in the first line, for future proofing
-public class AllowListFile {
+public final class AllowListFile {
     private Path path;
 
     public AllowListFile(Path path) {

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/AllowListFile.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/AllowListFile.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.GradleException;
 
-
 public final class AllowListFile {
     private Path path;
 

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -46,9 +46,10 @@ public class IncrementalConfigurationCachePlugin implements Plugin<Project> {
 
             project.getTasks().configureEach(task -> {
                 if (!enabledTasks.contains(task.getPath())) {
-                    task.notCompatibleWithConfigurationCache(String.format(
-                            "Configuration cache is not enabled for this task, as it was not included in %s",
-                            ALLOW_LIST_FILE));
+                    task.notCompatibleWithConfigurationCache(
+                            String.format(
+                                    "Configuration cache is not enabled for this task, as it was not included in %s",
+                                    ALLOW_LIST_FILE));
                 }
             });
         });

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -46,10 +46,9 @@ public class IncrementalConfigurationCachePlugin implements Plugin<Project> {
 
             project.getTasks().configureEach(task -> {
                 if (!enabledTasks.contains(task.getPath())) {
-                    task.notCompatibleWithConfigurationCache(
-                            String.format(
-                                    "Configuration cache is not enabled for this task, as it was not included in %s",
-                                    ALLOW_LIST_FILE));
+                    task.notCompatibleWithConfigurationCache(String.format(
+                            "Configuration cache is not enabled for this task, as it was not included in %s",
+                            ALLOW_LIST_FILE));
                 }
             });
         });

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -34,8 +34,8 @@ public class IncrementalConfigurationCachePlugin implements Plugin<Project> {
         Path allowlistPath = project.getRootProject().getProjectDir().toPath().resolve(ALLOW_LIST_FILE);
         if (!Files.exists(allowlistPath)) {
             log.warn(
-                    "Configuration cache allowed tasks file not found at: {}. " +
-                            "All tasks will be marked as incompatible with configuration cache.",
+                    "Configuration cache allowed tasks file not found at: {}. "
+                            + "All tasks will be marked as incompatible with configuration cache.",
                     allowlistPath.toAbsolutePath()
             );
             return;
@@ -47,7 +47,6 @@ public class IncrementalConfigurationCachePlugin implements Plugin<Project> {
 
             project.getTasks().configureEach(task -> {
                 if (!enabledTasks.contains(task.getPath())) {
-                    System.out.println("CC disabled for: " + task.getName());
                     task.notCompatibleWithConfigurationCache(
                             String.format(
                                     "Configuration cache is not enabled for this task, as it was not included in %s",

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -36,8 +36,7 @@ public class IncrementalConfigurationCachePlugin implements Plugin<Project> {
             log.warn(
                     "Configuration cache allowed tasks file not found at: {}. "
                             + "All tasks will be marked as incompatible with configuration cache.",
-                    allowlistPath.toAbsolutePath()
-            );
+                    allowlistPath.toAbsolutePath());
             return;
         }
 
@@ -47,10 +46,9 @@ public class IncrementalConfigurationCachePlugin implements Plugin<Project> {
 
             project.getTasks().configureEach(task -> {
                 if (!enabledTasks.contains(task.getPath())) {
-                    task.notCompatibleWithConfigurationCache(
-                            String.format(
-                                    "Configuration cache is not enabled for this task, as it was not included in %s",
-                                    ALLOW_LIST_FILE));
+                    task.notCompatibleWithConfigurationCache(String.format(
+                            "Configuration cache is not enabled for this task, as it was not included in %s",
+                            ALLOW_LIST_FILE));
                 }
             });
         });

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -125,7 +125,7 @@ case "$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-CLASSPATH=$APP_HOME/gradle-wrapper.jar
+CLASSPATH="\\\"\\\""
 
 
 # Determine the Java command to use to start the JVM.
@@ -224,7 +224,7 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
         -classpath "$CLASSPATH" \
-        org.gradle.wrapper.GradleWrapperMain \
+        -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
         "$@"
 
 # Stop when "xargs" is not available.


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Gradle wrapper wasn't properly configured in the initial commit. Checks wasn't running due to 

```
Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain
Caused by: java.lang.ClassNotFoundException: org.gradle.wrapper.GradleWrapperMain
```

Also, some checkstyle violations weren't caught in the initial commit, because it was pushed without review. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->


==COMMIT_MSG==
Fix Gradle Wrapper settings
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

