### PR TITLE
Explicate that plugin only works for tasks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ This plugin enables incrementally rolling out the Configuration Cache, one task 
 This plugin also prevents regressions — people adding Configuration Cache issues to tasks that already support them.
 
 
+## Limitations
+
+The plugin only disables Configuration Cache for tasks. If your configuration phase is not compatible with the cache, you must resolve those issues first.
+
 ## Configuration
 
 The only external dependency is the plain text file `gradle/configuration-cache-allowed-tasks` at the root of your project.  

--- a/changelog/@unreleased/pr-6.v2.yml
+++ b/changelog/@unreleased/pr-6.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Explicate that plugin only works for tasks in README
+  links:
+  - https://github.com/palantir/gradle-incremental-configuration-cache/pull/6

--- a/changelog/@unreleased/pr-6.v2.yml
+++ b/changelog/@unreleased/pr-6.v2.yml
@@ -1,5 +1,0 @@
-type: improvement
-improvement:
-  description: Explicate that plugin only works for tasks in README
-  links:
-  - https://github.com/palantir/gradle-incremental-configuration-cache/pull/6


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Open source users might get the wrong impression that this plugin is a panacea for all configuration cache problems. However, your builds won't run if you have configuration phase issues. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Explicate that plugin only works for tasks in README
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

