### PR TITLE
Update README with FAQ about gradle CC warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ To apply the plugin:
 apply plugin: 'com.palantir.incremental-configuration-cache'
 ```
 
+## FAQ
+
+#### After applying this plugin, I'm seeing "configuration cache problems found in this build". What's going on?
+
+Suppose a task `T` hasn't been [updated to support the configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements), and is not in `gradle/configuration-cache-allowed-tasks`. 
+
+When you [run gradle with the configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:usage:enable) , `T` will run successfully without the configuration cache, but all the configuration cache problems within `T`'s implementation will be surfaced as a warning to the user. Gradle does not provide a safe way to suppress these warnings. 
+
 
 ## Motivation
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

FLUP to https://github.com/palantir/gradle-incremental-configuration-cache/pull/3

We are rolling out the configuration cache with this plugin. During the transition period—before all tasks are fully compatible—tasks not included in the allow list will continue to run correctly without configuration cache. However, they will display a warning message that could unnecessarily alarm users and increase support requests:

![Screenshot 2025-06-18 at 13 58 09](https://github.com/user-attachments/assets/f0b366d8-749d-4f42-ad42-d46022c1bfa7)


## After this PR
<!-- User-facing outcomes this PR delivers go below -->

Add a FAQ which reassures users that their builds are just fine, while we chug along and make more tasks configuration cachable.

==COMMIT_MSG==
Update README with FAQ about gradle CC warnings
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

