### PR TITLE
Copy configuration-cache problems report to circle artifacts

### DIFF
--- a/gradle-incremental-configuration-cache/build.gradle
+++ b/gradle-incremental-configuration-cache/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'
 
+    implementation 'com.palantir.gradle.utils:environment-variables'
+
     testImplementation gradleTestKit()
     testImplementation 'com.netflix.nebula:nebula-test'
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/gradle-incremental-configuration-cache/build.gradle
+++ b/gradle-incremental-configuration-cache/build.gradle
@@ -35,3 +35,7 @@ gradlePlugin {
 gradleTestUtils {
     gradleVersions = ['8.14.3']
 }
+
+moduleJvmArgs {
+    opens('java.base/java.lang.invoke', 'java.base/java.lang.util', 'java.base/java.util')
+}

--- a/gradle-incremental-configuration-cache/build.gradle
+++ b/gradle-incremental-configuration-cache/build.gradle
@@ -37,7 +37,3 @@ gradlePlugin {
 gradleTestUtils {
     gradleVersions = ['8.14.3']
 }
-
-moduleJvmArgs {
-    opens('java.base/java.lang.invoke', 'java.base/java.lang.util', 'java.base/java.util')
-}

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -16,23 +16,17 @@
 
 package com.palantir.gradle.configcache.incremental;
 
-import java.io.File;
+import com.palantir.gradle.utils.environmentvariables.EnvironmentVariables;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 import javax.inject.Inject;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.file.ProjectLayout;
-import org.gradle.api.flow.BuildWorkResult;
-import org.gradle.api.flow.FlowAction;
-import org.gradle.api.flow.FlowParameters;
-import org.gradle.api.flow.FlowProviders;
-import org.gradle.api.flow.FlowScope;
-import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.Input;
-import org.gradle.internal.cc.impl.ConfigurationCacheKey;
+import org.gradle.api.tasks.Nested;
 import org.gradle.util.GradleVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,16 +38,10 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
     private static final GradleVersion MIN_GRADLE_VERSION = GradleVersion.version("8.12.0");
 
     @Inject
-    protected abstract FlowScope getFlowScope();
-
-    @Inject
-    protected abstract FlowProviders getFlowProviders();
-
-    @Inject
-    protected abstract ConfigurationCacheKey getConfigurationCacheKey();
-
-    @Inject
     protected abstract ProjectLayout getProjectLayout();
+
+    @Nested
+    protected abstract EnvironmentVariables getEnvironmentVariables();
 
     @Override
     public final void apply(Project project) {
@@ -85,36 +73,54 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
             }
         }));
 
-        getFlowScope().always(CopyConfigurationCacheProblems.class, spec -> {
-            spec.parameters(parameters -> {
-                parameters.getBuildWorkResult().set(getFlowProviders().getBuildWorkResult());
-                parameters
-                        .getConfigurationCacheProblemsFile()
-                        .set(getProjectLayout().getBuildDirectory().map(FileSystemLocation::getAsFile));
-                parameters
-                        .getOutputFile()
-                        .set(getProjectLayout().getBuildDirectory().map(FileSystemLocation::getAsFile));
-            });
-        });
+        ensureReportsDirIsSymlinkedToCircleArtifacts();
     }
 
-    static final class CopyConfigurationCacheProblems implements FlowAction<CopyConfigurationCacheProblems.Parameters> {
-        interface Parameters extends FlowParameters {
-            @Input
-            Property<BuildWorkResult> getBuildWorkResult();
-
-            @Input
-            Property<File> getConfigurationCacheProblemsFile();
-
-            @Input
-            Property<File> getOutputFile();
+    private void ensureReportsDirIsSymlinkedToCircleArtifacts() {
+        if (!getEnvironmentVariables().envVarOrFromTestingProperty("CIRCLECI").isPresent()) {
+            return;
         }
 
-        @Override
-        public void execute(Parameters parameters) throws Exception {
-            Files.copy(
-                    parameters.getConfigurationCacheProblemsFile().get().toPath(),
-                    parameters.getOutputFile().get().toPath());
+        Path originalConfigurationCacheReportsDir = getProjectLayout()
+                .getBuildDirectory()
+                .dir("reports/configuration-cache")
+                .get()
+                .getAsFile()
+                .toPath();
+
+        // If it already exists, a gradle invocation ran before and we should have already symlinked it
+        if (Files.exists(originalConfigurationCacheReportsDir)) {
+            return;
+        }
+
+        Path circleArtifactsConfigurationCacheReportsDir = Path.of(
+                getEnvironmentVariables()
+                        .envVarOrFromTestingProperty("CIRCLE_ARTIFACTS")
+                        // Some templates still do not set CIRCLE_ARTIFACTS :(
+                        .orElse("/home/circleci/artifacts")
+                        .get(),
+                "configuration-cache-reports");
+
+        createDirectories(originalConfigurationCacheReportsDir.getParent());
+        createDirectories(circleArtifactsConfigurationCacheReportsDir);
+
+        try {
+            Files.createSymbolicLink(originalConfigurationCacheReportsDir, circleArtifactsConfigurationCacheReportsDir);
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    "Could not symlink configuration cache reports dir ('%s') to circle artifacts ('%s')"
+                            .formatted(
+                                    originalConfigurationCacheReportsDir, circleArtifactsConfigurationCacheReportsDir),
+                    e);
+        }
+    }
+
+    private static void createDirectories(Path circleArtifactsConfigurationCacheReportsDir) {
+        try {
+            Files.createDirectories(circleArtifactsConfigurationCacheReportsDir);
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    "Could not create directories to '%s'".formatted(circleArtifactsConfigurationCacheReportsDir), e);
         }
     }
 }

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -115,12 +115,11 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
         }
     }
 
-    private static void createDirectories(Path circleArtifactsConfigurationCacheReportsDir) {
+    private static void createDirectories(Path directory) {
         try {
-            Files.createDirectories(circleArtifactsConfigurationCacheReportsDir);
+            Files.createDirectories(directory);
         } catch (IOException e) {
-            throw new UncheckedIOException(
-                    "Could not create directories to '%s'".formatted(circleArtifactsConfigurationCacheReportsDir), e);
+            throw new UncheckedIOException("Could not create directories to '%s'".formatted(directory), e);
         }
     }
 }

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -16,21 +16,44 @@
 
 package com.palantir.gradle.configcache.incremental;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
+import javax.inject.Inject;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.flow.BuildWorkResult;
+import org.gradle.api.flow.FlowAction;
+import org.gradle.api.flow.FlowParameters;
+import org.gradle.api.flow.FlowProviders;
+import org.gradle.api.flow.FlowScope;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.internal.cc.impl.ConfigurationCacheKey;
 import org.gradle.util.GradleVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class IncrementalConfigurationCachePlugin implements Plugin<Project> {
+public abstract class IncrementalConfigurationCachePlugin implements Plugin<Project> {
     private static final Logger log = LoggerFactory.getLogger(IncrementalConfigurationCachePlugin.class);
 
-    public static final Path ALLOW_LIST_FILE = Path.of("gradle/configuration-cache-allowed-tasks");
+    private static final Path ALLOW_LIST_FILE = Path.of("gradle/configuration-cache-allowed-tasks");
+    private static final GradleVersion MIN_GRADLE_VERSION = GradleVersion.version("8.12.0");
 
-    public static final GradleVersion MIN_GRADLE_VERSION = GradleVersion.version("8.12.0");
+    @Inject
+    protected abstract FlowScope getFlowScope();
+
+    @Inject
+    protected abstract FlowProviders getFlowProviders();
+
+    @Inject
+    protected abstract ConfigurationCacheKey getConfigurationCacheKey();
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @Override
     public final void apply(Project project) {
@@ -61,5 +84,37 @@ public class IncrementalConfigurationCachePlugin implements Plugin<Project> {
                                 .formatted(ALLOW_LIST_FILE));
             }
         }));
+
+        getFlowScope().always(CopyConfigurationCacheProblems.class, spec -> {
+            spec.parameters(parameters -> {
+                parameters.getBuildWorkResult().set(getFlowProviders().getBuildWorkResult());
+                parameters
+                        .getConfigurationCacheProblemsFile()
+                        .set(getProjectLayout().getBuildDirectory().map(FileSystemLocation::getAsFile));
+                parameters
+                        .getOutputFile()
+                        .set(getProjectLayout().getBuildDirectory().map(FileSystemLocation::getAsFile));
+            });
+        });
+    }
+
+    static final class CopyConfigurationCacheProblems implements FlowAction<CopyConfigurationCacheProblems.Parameters> {
+        interface Parameters extends FlowParameters {
+            @Input
+            Property<BuildWorkResult> getBuildWorkResult();
+
+            @Input
+            Property<File> getConfigurationCacheProblemsFile();
+
+            @Input
+            Property<File> getOutputFile();
+        }
+
+        @Override
+        public void execute(Parameters parameters) throws Exception {
+            Files.copy(
+                    parameters.getConfigurationCacheProblemsFile().get().toPath(),
+                    parameters.getOutputFile().get().toPath());
+        }
     }
 }

--- a/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheTest.groovy
+++ b/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheTest.groovy
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.palantir.gradle.configcache.incremental
+
+import groovy.io.FileType
 import nebula.test.IntegrationTestKitSpec
 
 
@@ -26,6 +28,11 @@ class IncrementalConfigurationCacheTest extends IntegrationTestKitSpec {
         buildFile << '''
             apply plugin: 'com.palantir.incremental-configuration-cache'
             apply plugin: 'java-library'
+        '''.stripIndent(true)
+
+        // Put environment-variables in testing mode
+        file('gradle.properties') << '''
+            __TESTING=true
         '''.stripIndent(true)
     }
 
@@ -117,6 +124,36 @@ class IncrementalConfigurationCacheTest extends IntegrationTestKitSpec {
 
         where:
         gradleVersion << ["8.12.1", "8.14.2"]
+    }
+
+    def 'copies configuration cache reports to circle artifacts'() {
+        file('gradle/configuration-cache-allowed-tasks') << ''
+
+        // language=Gradle
+        buildFile << '''
+            // Fail configuration cache at configuration time
+            'ls'.execute()
+        '''.stripIndent(true)
+
+        when: 'configuration cache is enabled, running on circleci'
+        def output = createRunner(
+                '--info',
+                '--configuration-cache',
+                '-P__TESTING_CIRCLECI=true',
+                '-P__TESTING_CIRCLE_ARTIFACTS=' + getProjectDir().toPath().resolve('circle-artifacts')
+        ).buildAndFail().output
+
+        then: 'it fails due to configuration cache problems, a configuration cache report is in the circle artifacts directory'
+        output.contains('Configuration cache problems found in this build')
+
+
+        def circleArtifactsReports = new File(projectDir, 'circle-artifacts/configuration-cache-reports')
+        circleArtifactsReports.exists()
+
+        def reports = []
+        circleArtifactsReports.traverse(type: FileType.FILES, maxDepth: 4) { reports.add(it) }
+
+        reports.size() == 1
     }
 
     private boolean runTasksWithConfigurationCache(String... tasks) {

--- a/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheTest.groovy
+++ b/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheTest.groovy
@@ -156,6 +156,33 @@ class IncrementalConfigurationCacheTest extends IntegrationTestKitSpec {
         reports.size() == 1
     }
 
+    def 'outputs configuration cache reports to normal location when running locally'() {
+        file('gradle/configuration-cache-allowed-tasks') << ''
+
+        // language=Gradle
+        buildFile << '''
+            // Fail configuration cache at configuration time
+            'ls'.execute()
+        '''.stripIndent(true)
+
+        when: 'configuration cache is enabled, running on circleci'
+        def output = createRunner(
+                '--info',
+                '--configuration-cache',
+        ).buildAndFail().output
+
+        then: 'it fails due to configuration cache problems, a configuration cache report is in the usual location'
+        output.contains('Configuration cache problems found in this build')
+
+        def circleArtifactsReports = new File(projectDir, 'build/reports/configuration-cache')
+        circleArtifactsReports.exists()
+
+        def reports = []
+        circleArtifactsReports.traverse(type: FileType.FILES, maxDepth: 4) { reports.add(it) }
+
+        reports.size() == 1
+    }
+
     private boolean runTasksWithConfigurationCache(String... tasks) {
         def firstRun = createRunner(tasks + ['--configuration-cache'] as String[]).build()
         def firstOutput = firstRun.output

--- a/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheTest.groovy
+++ b/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheTest.groovy
@@ -165,7 +165,7 @@ class IncrementalConfigurationCacheTest extends IntegrationTestKitSpec {
             'ls'.execute()
         '''.stripIndent(true)
 
-        when: 'configuration cache is enabled, running on circleci'
+        when: 'configuration cache is enabled, running locally'
         def output = createRunner(
                 '--info',
                 '--configuration-cache',

--- a/versions.lock
+++ b/versions.lock
@@ -1,4 +1,5 @@
 # Run ./gradlew writeVersionsLocks to regenerate this file
+com.palantir.gradle.utils:environment-variables:0.16.0 (1 constraints: 3905353b)
 org.immutables:value:2.11.3 (1 constraints: 3905353b)
 
 [Test dependencies]

--- a/versions.props
+++ b/versions.props
@@ -1,3 +1,4 @@
+com.palantir.gradle.utils:* = 0.16.0
 com.netflix.nebula:nebula-test = 10.6.2
 junit:junit = 4.13.2
 org.junit.jupiter:* = 5.13.4


### PR DESCRIPTION
## Before this PR
Currently, the configuration cache HTML report is generated on CI and just stays there. It's impossible to access it without ssh. We need this report to effectively diagnose configuration cache issues.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Configuration-cache HTML problems report is copied to circle artifacts
==COMMIT_MSG==

We do this by symlinking the default output dir to one in circle artifacts.

[Example output (internal circle)](https://pl.ntr/2wd)

## Possible downsides?
Symlinking the default output dir is less than ideal imo, but the other approaches I tried to not work:
1. Gradle provides no way to configure the report output dir
2. I tried using a `FlowAction` to copy the reports when the build finishes, but this actually happens far too soon - the configuration cache reports happen after this point.
3. We can't depend on JVM shutdown hooks to do this any later.
4. Reflecting in doing something like changing the implementation of the configuration cache report service is nasty and will likely immediately get broken by Gradle upgrades.

