### PR TITLE
Enable configuration cache for a task and all its dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Rolling out Gradle's Configuration Cache is hard. If you turn on the Configurati
 
 Annoyingly, warn mode [fails your builds if Configuration Cache problems are found](https://github.com/gradle/gradle/issues/25235). This deviates from the expected and desired behavior, which is to warn about Configuration Cache issues, but run the build without Configuration Cache successfully.
 
-This plugin enables incrementally rolling out the Configuration Cache, one task at a time. It reads `gradle/configuration-cache-allowed-tasks` for names of the tasks, and all their dependents, you want to run with the Configuration Cache, and turns off configuration caching for all other tasks in the project. This allows you to turn on running Configuration Cache by default, while incrementally fixing tasks and adding them to  `gradle/configuration-cache-allowed-tasks`.
+This plugin enables incrementally rolling out the Configuration Cache, one task at a time. It reads `gradle/configuration-cache-allowed-tasks` for names of the tasks, and all their dependencies, you want to run with the Configuration Cache, and turns off configuration caching for all other tasks in the project. This allows you to turn on running Configuration Cache by default, while incrementally fixing tasks and adding them to  `gradle/configuration-cache-allowed-tasks`.
 
 This plugin also prevents regressions — people adding Configuration Cache issues to tasks that already support them.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Rolling out Gradle's Configuration Cache is hard. If you turn on the Configurati
 
 Annoyingly, warn mode [fails your builds if Configuration Cache problems are found](https://github.com/gradle/gradle/issues/25235). This deviates from the expected and desired behavior, which is to warn about Configuration Cache issues, but run the build without Configuration Cache successfully.
 
-This plugin enables incrementally rolling out the Configuration Cache, one task at a time. It reads `gradle/configuration-cache-allowed-tasks` for fully qualified names of tasks you want to run with the Configuration Cache, and turns off configuration caching for all other tasks in the project. This allows you to turn on running Configuration Cache by default, while incrementally fixing tasks and adding them to  `gradle/configuration-cache-allowed-tasks`.
+This plugin enables incrementally rolling out the Configuration Cache, one task at a time. It reads `gradle/configuration-cache-allowed-tasks` for names of the tasks, and all their dependents, you want to run with the Configuration Cache, and turns off configuration caching for all other tasks in the project. This allows you to turn on running Configuration Cache by default, while incrementally fixing tasks and adding them to  `gradle/configuration-cache-allowed-tasks`.
 
 This plugin also prevents regressions — people adding Configuration Cache issues to tasks that already support them.
 

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/AllowListFile.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/AllowListFile.java
@@ -20,8 +20,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class AllowListFile {
     private final Path path;
@@ -34,12 +33,11 @@ public final class AllowListFile {
         }
     }
 
-    public Set<String> loadAllowedTasks() {
+    public Stream<String> loadAllowedTasks() {
         try {
             return Files.readAllLines(path).stream()
                     .map(String::trim)
-                    .filter(line -> !line.isEmpty() && !line.startsWith("#"))
-                    .collect(Collectors.toSet());
+                    .filter(line -> !line.isEmpty() && !line.startsWith("#"));
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read configuration cache allowed tasks file: " + path, e);
         }

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -77,7 +77,7 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
                     .flatMap(taskName -> findTasksAcrossAllProjects(project.getRootProject(), taskName))
                     .collect(Collectors.toSet());
 
-            // Get all the enabled tasks and there dependencies
+            // Get all the enabled tasks and their dependencies
             Set<Task> enabledTasksAndDependencies = collectTasksWithDependencies(enabledTasks);
 
             // Mark incompatible tasks

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -92,12 +92,12 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
     }
 
     private Stream<Task> findTasksAcrossAllProjects(Project rootProject, String taskName) {
-        if (!taskName.startsWith(":")) {
-            return Stream.of(rootProject.getTasks().findByName(taskName)).filter(Objects::nonNull);
+        if (taskName.startsWith(":")) {
+            return Stream.of(rootProject.getTasks().findByPath(taskName)).filter(Objects::nonNull);
         }
 
         return rootProject.getAllprojects().stream()
-                .map(project -> project.getTasks().findByPath(taskName))
+                .map(project -> project.getTasks().findByName(taskName))
                 .filter(Objects::nonNull);
     }
 

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -21,11 +21,14 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.Set;
 import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.tasks.Nested;
 import org.gradle.util.GradleVersion;
@@ -66,15 +69,29 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
         AllowListFile allowList = new AllowListFile(allowListPath);
         Set<String> enabledTasks = allowList.loadAllowedTasks();
 
-        project.getAllprojects().forEach(proj -> proj.getTasks().configureEach(task -> {
-            if (!enabledTasks.contains(task.getPath())) {
-                task.notCompatibleWithConfigurationCache(
-                        "Configuration cache is not enabled for this task, as it was not included in %s"
-                                .formatted(ALLOW_LIST_FILE));
-            }
-        }));
+        project.getGradle().getTaskGraph().whenReady(taskExecutionGraph -> {
+            Set<Task> allEnabledTasks = new HashSet<>();
+
+            // First pass: collect enabled tasks and dependencies
+            taskExecutionGraph.getAllTasks().stream()
+                    .filter(task -> enabledTasks.contains(task.getName()) || enabledTasks.contains(task.getPath()))
+                    .forEach(task -> collectTaskWithDependencies(taskExecutionGraph, task, allEnabledTasks));
+
+            // Second pass: mark incompatible tasks
+            taskExecutionGraph.getAllTasks().stream()
+                    .filter(task -> !allEnabledTasks.contains(task))
+                    .forEach(task -> task.notCompatibleWithConfigurationCache(
+                            "Configuration cache is not enabled for this task, as it was not included in %s"
+                                    .formatted(ALLOW_LIST_FILE)));
+        });
 
         ensureReportsDirIsSymlinkedToCircleArtifacts();
+    }
+
+    private void collectTaskWithDependencies(TaskExecutionGraph graph, Task task, Set<Task> collectedTasks) {
+        if (collectedTasks.add(task)) {
+            graph.getDependencies(task).forEach(dep -> collectTaskWithDependencies(graph, dep, collectedTasks));
+        }
     }
 
     private void ensureReportsDirIsSymlinkedToCircleArtifacts() {
@@ -135,6 +152,22 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
             Files.createDirectories(directory);
         } catch (IOException e) {
             throw new UncheckedIOException("Could not create directories to '%s'".formatted(directory), e);
+        }
+    }
+
+    private void addAllDependenciesRecursive(Task task, Set<Task> collectedTasks, TaskExecutionGraph graph) {
+        // Get dependencies from the task graph (returns immutable set)
+        Set<Task> graphDependencies = graph.getDependencies(task);
+
+        // Create a new mutable set to work with
+        Set<Task> allDependencies = new HashSet<>(graphDependencies);
+
+        // Process each dependency
+        for (Task depTask : allDependencies) {
+            if (collectedTasks.add(depTask)) { // Only process if newly added
+                System.out.println("  -> Adding dependency: " + depTask.getPath());
+                addAllDependenciesRecursive(depTask, collectedTasks, graph);
+            }
         }
     }
 }

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -154,20 +154,4 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
             throw new UncheckedIOException("Could not create directories to '%s'".formatted(directory), e);
         }
     }
-
-    private void addAllDependenciesRecursive(Task task, Set<Task> collectedTasks, TaskExecutionGraph graph) {
-        // Get dependencies from the task graph (returns immutable set)
-        Set<Task> graphDependencies = graph.getDependencies(task);
-
-        // Create a new mutable set to work with
-        Set<Task> allDependencies = new HashSet<>(graphDependencies);
-
-        // Process each dependency
-        for (Task depTask : allDependencies) {
-            if (collectedTasks.add(depTask)) { // Only process if newly added
-                System.out.println("  -> Adding dependency: " + depTask.getPath());
-                addAllDependenciesRecursive(depTask, collectedTasks, graph);
-            }
-        }
-    }
 }

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -22,6 +22,8 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
 import java.util.Set;
 import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
@@ -89,8 +91,14 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
     }
 
     private void collectTaskWithDependencies(TaskExecutionGraph graph, Task task, Set<Task> collectedTasks) {
-        if (collectedTasks.add(task)) {
-            graph.getDependencies(task).forEach(dep -> collectTaskWithDependencies(graph, dep, collectedTasks));
+        Queue<Task> toProcess = new LinkedList<>();
+        toProcess.offer(task);
+
+        while (!toProcess.isEmpty()) {
+            Task current = toProcess.poll();
+            if (collectedTasks.add(current)) {
+                graph.getDependencies(current).forEach(toProcess::offer);
+            }
         }
     }
 

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -92,14 +92,12 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
     }
 
     private Stream<Task> findTasksAcrossAllProjects(Project rootProject, String taskName) {
+        if (!taskName.startsWith(":")) {
+            return Stream.of(rootProject.getTasks().findByName(taskName)).filter(Objects::nonNull);
+        }
+
         return rootProject.getAllprojects().stream()
-                .map(project -> {
-                    if (taskName.startsWith(":")) {
-                        return rootProject.getTasks().findByPath(taskName);
-                    } else {
-                        return project.getTasks().findByName(taskName);
-                    }
-                })
+                .map(project -> project.getTasks().findByPath(taskName))
                 .filter(Objects::nonNull);
     }
 

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -74,7 +74,7 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
             // Get enabled tasks
             Set<Task> enabledTasks = new AllowListFile(allowListPath)
                     .loadAllowedTasks()
-                    .flatMap(taskName -> findTasksAcrossAllProjects(project, taskName))
+                    .flatMap(taskName -> findTasksAcrossAllProjects(project.getRootProject(), taskName))
                     .collect(Collectors.toSet());
 
             // Get all the enabled tasks and there dependencies
@@ -91,13 +91,13 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
         ensureReportsDirIsSymlinkedToCircleArtifacts();
     }
 
-    private Stream<Task> findTasksAcrossAllProjects(Project project, String taskName) {
-        return project.getRootProject().getAllprojects().stream()
-                .map(proj -> {
+    private Stream<Task> findTasksAcrossAllProjects(Project rootProject, String taskName) {
+        return rootProject.getAllprojects().stream()
+                .map(project -> {
                     if (taskName.startsWith(":")) {
-                        return project.getRootProject().getTasks().findByPath(taskName);
+                        return rootProject.getTasks().findByPath(taskName);
                     } else {
-                        return proj.getTasks().findByName(taskName);
+                        return project.getTasks().findByName(taskName);
                     }
                 })
                 .filter(Objects::nonNull);

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Set;
 import javax.inject.Inject;
@@ -91,7 +91,7 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
     }
 
     private void collectTaskWithDependencies(TaskExecutionGraph graph, Task task, Set<Task> collectedTasks) {
-        Queue<Task> toProcess = new LinkedList<>();
+        Queue<Task> toProcess = new ArrayDeque<>();
         toProcess.offer(task);
 
         while (!toProcess.isEmpty()) {

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -25,6 +25,7 @@ import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.Queue;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.Plugin;
@@ -72,14 +73,15 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
         Set<String> enabledTasks = allowList.loadAllowedTasks();
 
         project.getGradle().getTaskGraph().whenReady(taskExecutionGraph -> {
-            Set<Task> allEnabledTasks = new HashSet<>();
-
-            // First pass: collect enabled tasks and dependencies
-            taskExecutionGraph.getAllTasks().stream()
+            // Collect initial enabled tasks
+            Set<Task> initialEnabledTasks = taskExecutionGraph.getAllTasks().stream()
                     .filter(task -> enabledTasks.contains(task.getName()) || enabledTasks.contains(task.getPath()))
-                    .forEach(task -> collectTaskWithDependencies(taskExecutionGraph, task, allEnabledTasks));
+                    .collect(Collectors.toSet());
 
-            // Second pass: mark incompatible tasks
+            // Get all enabled tasks including dependencies
+            Set<Task> allEnabledTasks = collectTasksWithDependencies(taskExecutionGraph, initialEnabledTasks);
+
+            // Mark incompatible tasks
             taskExecutionGraph.getAllTasks().stream()
                     .filter(task -> !allEnabledTasks.contains(task))
                     .forEach(task -> task.notCompatibleWithConfigurationCache(
@@ -90,9 +92,9 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
         ensureReportsDirIsSymlinkedToCircleArtifacts();
     }
 
-    private void collectTaskWithDependencies(TaskExecutionGraph graph, Task task, Set<Task> collectedTasks) {
-        Queue<Task> toProcess = new ArrayDeque<>();
-        toProcess.offer(task);
+    private Set<Task> collectTasksWithDependencies(TaskExecutionGraph graph, Set<Task> initialTasks) {
+        Set<Task> collectedTasks = new HashSet<>();
+        Queue<Task> toProcess = new ArrayDeque<>(initialTasks);
 
         while (!toProcess.isEmpty()) {
             Task current = toProcess.poll();
@@ -100,6 +102,8 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
                 graph.getDependencies(current).forEach(toProcess::offer);
             }
         }
+
+        return collectedTasks;
     }
 
     private void ensureReportsDirIsSymlinkedToCircleArtifacts() {

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -23,15 +23,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.tasks.Nested;
 import org.gradle.util.GradleVersion;
@@ -69,21 +70,19 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
                     "Configuration cache allowed tasks file not found at %s".formatted(allowListPath));
         }
 
-        AllowListFile allowList = new AllowListFile(allowListPath);
-        Set<String> enabledTasks = allowList.loadAllowedTasks();
-
         project.getGradle().getTaskGraph().whenReady(taskExecutionGraph -> {
-            // Collect initial enabled tasks
-            Set<Task> initialEnabledTasks = taskExecutionGraph.getAllTasks().stream()
-                    .filter(task -> enabledTasks.contains(task.getName()) || enabledTasks.contains(task.getPath()))
+            // Get enabled tasks
+            Set<Task> enabledTasks = new AllowListFile(allowListPath)
+                    .loadAllowedTasks()
+                    .flatMap(taskName -> findTasksAcrossAllProjects(project, taskName))
                     .collect(Collectors.toSet());
 
-            // Get all enabled tasks including dependencies
-            Set<Task> allEnabledTasks = collectTasksWithDependencies(taskExecutionGraph, initialEnabledTasks);
+            // Get all the enabled tasks and there dependencies
+            Set<Task> enabledTasksAndDependencies = collectTasksWithDependencies(enabledTasks);
 
             // Mark incompatible tasks
             taskExecutionGraph.getAllTasks().stream()
-                    .filter(task -> !allEnabledTasks.contains(task))
+                    .filter(task -> !enabledTasksAndDependencies.contains(task))
                     .forEach(task -> task.notCompatibleWithConfigurationCache(
                             "Configuration cache is not enabled for this task, as it was not included in %s"
                                     .formatted(ALLOW_LIST_FILE)));
@@ -92,14 +91,26 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
         ensureReportsDirIsSymlinkedToCircleArtifacts();
     }
 
-    private Set<Task> collectTasksWithDependencies(TaskExecutionGraph graph, Set<Task> initialTasks) {
+    private Stream<Task> findTasksAcrossAllProjects(Project project, String taskName) {
+        return project.getRootProject().getAllprojects().stream()
+                .map(proj -> {
+                    if (taskName.startsWith(":")) {
+                        return project.getRootProject().getTasks().findByPath(taskName);
+                    } else {
+                        return proj.getTasks().findByName(taskName);
+                    }
+                })
+                .filter(Objects::nonNull);
+    }
+
+    private Set<Task> collectTasksWithDependencies(Set<Task> initialTasks) {
         Set<Task> collectedTasks = new HashSet<>();
         Queue<Task> toProcess = new ArrayDeque<>(initialTasks);
 
         while (!toProcess.isEmpty()) {
             Task current = toProcess.poll();
             if (collectedTasks.add(current)) {
-                graph.getDependencies(current).forEach(toProcess::offer);
+                current.getTaskDependencies().getDependencies(current).forEach(toProcess::offer);
             }
         }
 

--- a/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheTest.groovy
+++ b/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheTest.groovy
@@ -196,6 +196,66 @@ class IncrementalConfigurationCacheTest extends ConfigurationCacheSpec {
         result2.output.contains('Configuration cache entry discarded because incompatible tasks were found')
     }
 
+    def 'discovers transitive dependencies for configuration cache'() {
+        given: 'a chain of task dependencies'
+        // language=gradle
+        buildFile << '''
+            tasks.register('level3Dependency'){
+                doLast {
+                    println "Level 3 dependency executed"
+                }
+            }
+            
+            tasks.register('level2Dependency'){
+                dependsOn level3Dependency
+                doLast {
+                    println "Level 2 dependency executed"
+                }
+            }
+            
+            tasks.register('level1Dependency'){
+                dependsOn level2Dependency
+                doLast {
+                    println "Level 1 dependency executed"
+                }
+            }
+            
+            tasks.register('mainTask'){
+                dependsOn level1Dependency
+                doLast {
+                    println "Main task executed"
+                }
+            }
+        '''.stripIndent(true)
+
+        and: 'allow list only contains the main task'
+            file('gradle/configuration-cache-allowed-tasks') << '''
+            mainTask
+        '''.stripIndent(true)
+
+        when: 'running the main task with configuration cache'
+        def result = runTasksWithConfigurationCacheAndCheck('mainTask')
+
+        then: 'configuration cache is enabled (meaning all transitive dependencies were discovered)'
+        result.output.contains('Configuration cache entry stored')
+
+        and: 'all tasks in the dependency chain executed'
+        result.output.contains('Level 3 dependency executed')
+        result.output.contains('Level 2 dependency executed')
+        result.output.contains('Level 1 dependency executed')
+        result.output.contains('Main task executed')
+
+        when: 'running a lower level task'
+        def result2 = runTasksWithConfigurationCacheAndCheck('level2Dependency')
+
+        then: 'configuration cache is enabled (meaning all transitive dependencies were discovered)'
+        result2.output.contains('Configuration cache entry stored')
+
+        and: 'all tasks in the dependency chain executed'
+        result2.output.contains('Level 3 dependency executed')
+        result2.output.contains('Level 2 dependency executed')
+    }
+
     def 'copies configuration cache reports to circle artifacts'() {
         file('gradle/configuration-cache-allowed-tasks') << ''
 

--- a/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheTest.groovy
+++ b/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheTest.groovy
@@ -126,19 +126,6 @@ class IncrementalConfigurationCacheTest extends ConfigurationCacheSpec {
         gradleVersion << ["8.12.1", "8.14.2"]
     }
 
-    def 'allows tasks by name without path prefix'() {
-        given: 'allow list with task name only'
-        file('gradle/configuration-cache-allowed-tasks') << '''
-            classes
-        '''.stripIndent(true)
-
-        when:
-        def result = runTasksWithConfigurationCacheAndCheck('classes')
-
-        then: 'task matched by name runs with config cache'
-        result.output.contains('Configuration cache entry stored')
-    }
-
     def 'task name matches across subprojects'() {
         given: 'multi-project build with same task name in multiple projects'
         settingsFile << '''

--- a/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheTest.groovy
+++ b/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheTest.groovy
@@ -126,6 +126,89 @@ class IncrementalConfigurationCacheTest extends ConfigurationCacheSpec {
         gradleVersion << ["8.12.1", "8.14.2"]
     }
 
+    def 'allows tasks by name without path prefix'() {
+        given: 'allow list with task name only'
+        file('gradle/configuration-cache-allowed-tasks') << '''
+            classes
+        '''.stripIndent(true)
+
+        when:
+        def result = runTasksWithConfigurationCacheAndCheck('classes')
+
+        then: 'task matched by name runs with config cache'
+        result.output.contains('Configuration cache entry stored')
+    }
+
+    def 'task name matches across subprojects'() {
+        given: 'multi-project build with same task name in multiple projects'
+        settingsFile << '''
+            include 'sub1'
+            include 'sub2'
+        '''.stripIndent(true)
+
+        file('sub1/build.gradle') << '''
+            apply plugin: 'java-library'
+        '''.stripIndent(true)
+
+        file('sub2/build.gradle') << '''
+            apply plugin: 'java-library'
+        '''.stripIndent(true)
+
+        file('gradle/configuration-cache-allowed-tasks') << '''
+            compileJava
+        '''.stripIndent(true)
+
+        when: 'running task in sub1'
+        def result1 = runTasksWithConfigurationCacheAndCheck(':sub1:compileJava')
+
+        then: 'task matched by name runs with config cache'
+        result1.output.contains('Configuration cache entry stored')
+
+        when: 'running task in sub2'
+        def result2 = runTasksWithConfigurationCacheAndCheck(':sub2:compileJava')
+
+        then: 'same task name in different project also works'
+        result2.output.contains('Configuration cache entry stored')
+
+        when: 'running task at top level'
+        def result3 = runTasksWithConfigurationCacheAndCheck('compileJava')
+
+        then: 'same task name in different projects also work'
+        result3.output.contains('Configuration cache entry stored')
+    }
+
+    def 'full path takes precedence for specific project'() {
+        given: 'allow list with both name and full path'
+        settingsFile << '''
+            include 'sub1'
+            include 'sub2'
+        '''.stripIndent(true)
+
+        file('sub1/build.gradle') << '''
+            apply plugin: 'java-library'
+        '''.stripIndent(true)
+
+        file('sub2/build.gradle') << '''
+            apply plugin: 'java-library'
+        '''.stripIndent(true)
+
+        file('gradle/configuration-cache-allowed-tasks') << '''
+            :sub1:classes
+        '''.stripIndent(true)
+
+        when: 'running allowed task'
+        def result1 = runTasksWithConfigurationCacheAndCheck(':sub1:classes')
+
+        then: 'task with full path match runs with config cache'
+        result1.output.contains('Configuration cache entry stored')
+
+        when: 'running same task name in different project'
+        def result2 = runTasks(':sub2:classes', '--configuration-cache')
+
+        then: 'task without match does not use config cache'
+        result2.output.contains('Configuration cache entry discarded because incompatible tasks were found')
+    }
+
     def 'copies configuration cache reports to circle artifacts'() {
         file('gradle/configuration-cache-allowed-tasks') << ''
 


### PR DESCRIPTION
## Before this PR
We used to require the fully qualified task in the allow list file, this was brittle as if a new project was added it would stop running with configuration cache if a user say ran `./gradlew classes`

## After this PR
The plugin now properly handles task dependencies when determining configuration cache compatibility. When a task is enabled in the allow list, all of its dependencies are also automatically considered compatible with configuration cache.

This means a user can enter either `classes` or `:classes` into the allow list and get the expected behaviour 
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Enable configuration cache for a task and all its dependencies 

When a task is enabled for configuration cache via the allow list, automatically mark all of its transitive dependencies as compatible as well. 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
This solution requires the full task graph of all tasks in the allow list to be resolved no matter the task running which can be expensive for large projects
