### PR TITLE
Introduce lock file and add check / fix task

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,34 @@ The plugin only disables Configuration Cache for tasks. If your configuration ph
 
 ## Configuration
 
-The only external dependency is the plain text file `gradle/configuration-cache-allowed-tasks` at the root of your project.  
+This plugin uses a two-file system to manage which tasks run with configuration cache enabled:
+
+### `gradle/configuration-cache-allowed-tasks`
+A plain text file containing high-level task names you want to enable for configuration cache. For example:
+```
+classes
+test
+jar
+```
+
+### `gradle/configuration-cache-allowed-tasks.lock`
+An auto-generated lock file containing the exact task paths that will run when executing the tasks from the allowed-tasks file. This file is automatically maintained by the `checkConfigurationCacheLock` task.
+
+### Managing the lock file
+
+The plugin provides a `checkConfigurationCacheLock` task that:
+- **Validates** the lock file matches what would actually execute (runs automatically as part of `check`)
+- **Updates** the lock file when run with `--fix` flag
+
+#### Updating after project changes
+When you add subprojects, rename tasks, or modify task dependencies:
+```bash
+# Update the lock file to match the new project structure
+./gradlew checkConfigurationCacheLock --fix
+```
+
+#### CI validation
+The `checkConfigurationCacheLock` task is automatically added to the `check` lifecycle task, ensuring your lock file stays up-to-date:
+```bash
+./gradlew check  # Fails if lock file is out of date
+```

--- a/gradle-incremental-configuration-cache/build.gradle
+++ b/gradle-incremental-configuration-cache/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     implementation 'com.palantir.gradle.utils:environment-variables'
     implementation 'commons-io:commons-io'
+    implementation 'com.google.guava:guava'
 
     testImplementation gradleTestKit()
     testImplementation 'com.netflix.nebula:nebula-test'

--- a/gradle-incremental-configuration-cache/build.gradle
+++ b/gradle-incremental-configuration-cache/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation 'com.palantir.gradle.utils:environment-variables'
     implementation 'commons-io:commons-io'
     implementation 'com.google.guava:guava'
+    implementation 'com.palantir.gradle.failure-reports:gradle-failure-reports-exceptions'
 
     testImplementation gradleTestKit()
     testImplementation 'com.netflix.nebula:nebula-test'

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.inject.Inject;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -43,7 +44,8 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
             description = "Whether to apply the suggested fix to configuration-cache-allowed-tasks.lock")
     public abstract Property<Boolean> getShouldFix();
 
-    CheckConfigurationCacheLockTask() {
+    @Inject
+    public CheckConfigurationCacheLockTask() {
         getArguments().set(List.of("--quiet", "-Pconfiguration-cache-incompatible-for-all-tasks"));
         getDryRunResult()
                 .set(getTemporaryDir()

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
@@ -34,7 +34,7 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    public abstract ConfigurableFileCollection getLock();
+    public abstract ConfigurableFileCollection getLockFile();
 
     @Input
     @Option(
@@ -44,7 +44,7 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
 
     @TaskAction
     public final void check() {
-        Path lockPath = getLock().getSingleFile().toPath();
+        Path lockPath = getLockFile().getSingleFile().toPath();
         if (Files.notExists(lockPath) && !getShouldFix().get()) {
             throw new ExceptionWithSuggestion(
                     """

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
@@ -52,7 +52,7 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
                     "./gradlew :checkConfigurationCacheLock --fix");
         }
 
-        Set<String> dryRanTasks = dryRun(List.of("--quiet", "-Pconfiguration-cache-compatible-for-all-tasks"));
+        Set<String> dryRanTasks = dryRun(List.of("--quiet", "-Pconfiguration-cache-incompatible-for-all-tasks"));
 
         if (getShouldFix().get()) {
             TaskListFile.write(lockPath, dryRanTasks);

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
@@ -1,0 +1,126 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.configcache.incremental;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.gradle.api.UncheckedIOException;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+
+public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
+
+    @Input
+    public abstract Property<TaskListFile> getLock();
+
+    @Input
+    @Option(
+            option = "fix",
+            description = "Whether to apply the suggested fix to configuration-cache-allowed-tasks.lock")
+    public abstract Property<Boolean> getShouldFix();
+
+    @TaskAction
+    public final void check() {
+        Path lockPath = getLock().get().path();
+
+        // Check if lock file exists
+        if (!Files.exists(lockPath)) {
+            if (getShouldFix().get()) {
+                getLogger().info("Creating missing lock file at {}", lockPath);
+                try {
+                    Files.createFile(lockPath);
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Failed to create lock file", e);
+                }
+            } else {
+                throw new RuntimeException(
+                        """
+                    Lock file does not exist at %s.
+                    Run `./gradlew :checkConfigurationCacheLock --fix` to create the lock file.
+                    """
+                                .formatted(lockPath));
+            }
+        }
+
+        Set<String> dryRanTasks = dryRun(List.of("--quiet", "-PDISABLE_CONFIGURATION_CACHE=true"));
+        Set<String> lockFileTasks = getLock().get().loadTasks();
+
+        if (lockFileTasks.equals(dryRanTasks)) {
+            getLogger().lifecycle("Lock file is up to date with {} tasks", lockFileTasks.size());
+            return;
+        }
+
+        // Find differences
+        Set<String> inLockNotInDryRun = new HashSet<>(lockFileTasks);
+        inLockNotInDryRun.removeAll(dryRanTasks);
+
+        Set<String> inDryRunNotInLock = new HashSet<>(dryRanTasks);
+        inDryRunNotInLock.removeAll(lockFileTasks);
+
+        if (getShouldFix().get()) {
+            TaskListFile.write(lockPath, dryRanTasks);
+        } else {
+            String diffMessage =
+                    buildLockFileDiffMessage(lockFileTasks, dryRanTasks, inLockNotInDryRun, inDryRunNotInLock);
+            throw new RuntimeException(diffMessage);
+        }
+    }
+
+    private String buildLockFileDiffMessage(
+            Set<String> lockFileTasks,
+            Set<String> dryRanTasks,
+            Set<String> inLockNotInDryRun,
+            Set<String> inDryRunNotInLock) {
+
+        StringBuilder diffMessage = new StringBuilder();
+        diffMessage.append(
+                """
+                Lock file does not match the tasks that would run.
+                Run `./gradlew :checkConfigurationCacheLock --fix` to update the lock file.
+                """);
+
+        if (!inLockNotInDryRun.isEmpty()) {
+            diffMessage.append("Tasks in lock file but NOT executed (may have been removed or renamed):\n");
+            inLockNotInDryRun.stream()
+                    .sorted()
+                    .forEach(task -> diffMessage.append("  - ").append(task).append("\n"));
+            diffMessage.append("\n");
+        }
+
+        if (!inDryRunNotInLock.isEmpty()) {
+            diffMessage.append("Tasks that would be executed but NOT in lock file:\n");
+            inDryRunNotInLock.stream()
+                    .sorted()
+                    .forEach(task -> diffMessage.append("  + ").append(task).append("\n"));
+            diffMessage.append("\n");
+        }
+
+        diffMessage
+                .append("Total tasks in lock file: ")
+                .append(lockFileTasks.size())
+                .append("\n");
+        diffMessage.append("Total tasks that would execute: ").append(dryRanTasks.size());
+
+        return diffMessage.toString();
+    }
+}

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.configcache.incremental;
 
+import com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,7 +45,7 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
         Path lockPath = getLock().get().path();
 
         // Check if lock file exists
-        if (!Files.exists(lockPath)) {
+        if (Files.notExists(lockPath)) {
             if (getShouldFix().get()) {
                 getLogger().info("Creating missing lock file at {}", lockPath);
                 try {
@@ -53,16 +54,17 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
                     throw new UncheckedIOException("Failed to create lock file", e);
                 }
             } else {
-                throw new RuntimeException(
+                throw new ExceptionWithSuggestion(
                         """
                     Lock file does not exist at %s.
                     Run `./gradlew :checkConfigurationCacheLock --fix` to create the lock file.
                     """
-                                .formatted(lockPath));
+                                .formatted(lockPath),
+                        "./gradlew :checkConfigurationCacheLock --fix");
             }
         }
 
-        Set<String> dryRanTasks = dryRun(List.of("--quiet", "-PDISABLE_CONFIGURATION_CACHE=true"));
+        Set<String> dryRanTasks = dryRun(List.of("--quiet", "-Pconfiguration-cache-compatible-for-all-tasks"));
         Set<String> lockFileTasks = getLock().get().loadTasks();
 
         if (lockFileTasks.equals(dryRanTasks)) {

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
@@ -20,6 +20,7 @@ import com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
@@ -41,6 +42,15 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
             option = "fix",
             description = "Whether to apply the suggested fix to configuration-cache-allowed-tasks.lock")
     public abstract Property<Boolean> getShouldFix();
+
+    CheckConfigurationCacheLockTask() {
+        getArguments().set(List.of("--quiet", "-Pconfiguration-cache-incompatible-for-all-tasks"));
+        getDryRunResult()
+                .set(getTemporaryDir()
+                        .toPath()
+                        .resolve("dryRunNoConfigurationCache")
+                        .toFile());
+    }
 
     @TaskAction
     public final void check() {

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
@@ -20,17 +20,21 @@ import com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
 public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
 
-    @Input
-    public abstract Property<TaskListFile> getLock();
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getLock();
 
     @Input
     @Option(
@@ -40,8 +44,7 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
 
     @TaskAction
     public final void check() {
-        Path lockPath = getLock().get().path();
-
+        Path lockPath = getLock().getSingleFile().toPath();
         if (Files.notExists(lockPath) && !getShouldFix().get()) {
             throw new ExceptionWithSuggestion(
                     """
@@ -52,7 +55,7 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
                     "./gradlew :checkConfigurationCacheLock --fix");
         }
 
-        Set<String> dryRanTasks = dryRun(List.of("--quiet", "-Pconfiguration-cache-incompatible-for-all-tasks"));
+        Set<String> dryRanTasks = dryRunResult();
 
         if (getShouldFix().get()) {
             TaskListFile.write(lockPath, dryRanTasks);
@@ -60,7 +63,7 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
             return;
         }
 
-        Set<String> lockFileTasks = getLock().get().loadTasks();
+        Set<String> lockFileTasks = new TaskListFile(lockPath).loadTasks();
 
         if (lockFileTasks.equals(dryRanTasks)) {
             getLogger().lifecycle("Lock file is up to date with {} tasks", lockFileTasks.size());

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
@@ -17,13 +17,11 @@
 package com.palantir.gradle.configcache.incremental;
 
 import com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.gradle.api.UncheckedIOException;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
@@ -44,27 +42,24 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
     public final void check() {
         Path lockPath = getLock().get().path();
 
-        // Check if lock file exists
-        if (Files.notExists(lockPath)) {
-            if (getShouldFix().get()) {
-                getLogger().info("Creating missing lock file at {}", lockPath);
-                try {
-                    Files.createFile(lockPath);
-                } catch (IOException e) {
-                    throw new UncheckedIOException("Failed to create lock file", e);
-                }
-            } else {
-                throw new ExceptionWithSuggestion(
-                        """
-                    Lock file does not exist at %s.
-                    Run `./gradlew :checkConfigurationCacheLock --fix` to create the lock file.
+        if (Files.notExists(lockPath) && !getShouldFix().get()) {
+            throw new ExceptionWithSuggestion(
                     """
-                                .formatted(lockPath),
-                        "./gradlew :checkConfigurationCacheLock --fix");
-            }
+                Lock file does not exist at %s.
+                Run `./gradlew :checkConfigurationCacheLock --fix` to create the lock file.
+                """
+                            .formatted(lockPath),
+                    "./gradlew :checkConfigurationCacheLock --fix");
         }
 
         Set<String> dryRanTasks = dryRun(List.of("--quiet", "-Pconfiguration-cache-compatible-for-all-tasks"));
+
+        if (getShouldFix().get()) {
+            TaskListFile.write(lockPath, dryRanTasks);
+            getLogger().lifecycle("Lock file updated with {} tasks", dryRanTasks.size());
+            return;
+        }
+
         Set<String> lockFileTasks = getLock().get().loadTasks();
 
         if (lockFileTasks.equals(dryRanTasks)) {
@@ -72,20 +67,14 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
             return;
         }
 
-        // Find differences
         Set<String> inLockNotInDryRun = new HashSet<>(lockFileTasks);
         inLockNotInDryRun.removeAll(dryRanTasks);
 
         Set<String> inDryRunNotInLock = new HashSet<>(dryRanTasks);
         inDryRunNotInLock.removeAll(lockFileTasks);
 
-        if (getShouldFix().get()) {
-            TaskListFile.write(lockPath, dryRanTasks);
-        } else {
-            String diffMessage =
-                    buildLockFileDiffMessage(lockFileTasks, dryRanTasks, inLockNotInDryRun, inDryRunNotInLock);
-            throw new RuntimeException(diffMessage);
-        }
+        String diffMessage = buildLockFileDiffMessage(lockFileTasks, dryRanTasks, inLockNotInDryRun, inDryRunNotInLock);
+        throw new RuntimeException(diffMessage);
     }
 
     private String buildLockFileDiffMessage(

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
@@ -46,7 +46,8 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
 
     @Inject
     public CheckConfigurationCacheLockTask() {
-        getArguments().set(List.of("--quiet", "-Pconfiguration-cache-incompatible-for-all-tasks"));
+        getArguments().set(List.of("--quiet", "--no-configuration-cache"));
+        getShouldFix().set(false);
         getDryRunResult()
                 .set(getTemporaryDir()
                         .toPath()

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockTask.java
@@ -22,7 +22,6 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.inject.Inject;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -44,7 +43,6 @@ public abstract class CheckConfigurationCacheLockTask extends DryRunTask {
             description = "Whether to apply the suggested fix to configuration-cache-allowed-tasks.lock")
     public abstract Property<Boolean> getShouldFix();
 
-    @Inject
     public CheckConfigurationCacheLockTask() {
         getArguments().set(List.of("--quiet", "--no-configuration-cache"));
         getShouldFix().set(false);

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/DryRunTask.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/DryRunTask.java
@@ -19,7 +19,6 @@ package com.palantir.gradle.configcache.incremental;
 import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
@@ -27,10 +26,13 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
-import org.gradle.tooling.GradleConnectionException;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ProjectConnection;
 
@@ -40,18 +42,25 @@ public abstract class DryRunTask extends DefaultTask {
     public abstract SetProperty<String> getTasks();
 
     @Input
+    public abstract ListProperty<String> getArguments();
+
+    @Input
     @org.gradle.api.tasks.Optional
     public abstract Property<String> getInitScript();
 
     @Inject
     protected abstract ProjectLayout getProjectLayout();
 
-    public final Set<String> dryRun(List<String> args) throws GradleConnectionException {
+    @OutputFile
+    public abstract RegularFileProperty getDryRunResult();
+
+    @TaskAction
+    public final void dryRun() {
         Set<String> tasks = getTasks().get();
 
         if (tasks.isEmpty()) {
             getLogger().info("No tasks to dry-run");
-            return new TreeSet<>();
+            TaskListFile.write(getDryRunResult().getAsFile().get().toPath(), new TreeSet<>());
         }
 
         getLogger().info("Dry-running {} tasks", tasks.size());
@@ -64,7 +73,7 @@ public abstract class DryRunTask extends DefaultTask {
 
             connection
                     .newBuild()
-                    .withArguments(buildArguments(args))
+                    .withArguments(buildArguments())
                     .forTasks(tasks.toArray(new String[0]))
                     .setStandardOutput(outputStream)
                     .setStandardError(outputStream)
@@ -72,18 +81,20 @@ public abstract class DryRunTask extends DefaultTask {
 
             getLogger().info("All {} tasks passed dry-ran successfully", tasks.size());
 
-            return Pattern.compile("(:[\\w:-]+)\\s+SKIPPED")
-                    .matcher(outputStream.toString(StandardCharsets.UTF_8))
-                    .results()
-                    .map(m -> m.group(1))
-                    .collect(Collectors.toCollection(TreeSet::new));
+            TaskListFile.write(
+                    getDryRunResult().getAsFile().get().toPath(),
+                    Pattern.compile("(:[\\w:-]+)\\s+SKIPPED")
+                            .matcher(outputStream.toString(StandardCharsets.UTF_8))
+                            .results()
+                            .map(m -> m.group(1))
+                            .collect(Collectors.toCollection(TreeSet::new)));
         }
     }
 
-    private ImmutableList<String> buildArguments(List<String> args) {
+    private ImmutableList<String> buildArguments() {
         ImmutableList.Builder<String> argumentsBuilder = ImmutableList.builder();
         argumentsBuilder.add("--dry-run");
-        argumentsBuilder.addAll(args);
+        argumentsBuilder.addAll(getArguments().get());
 
         // GradleConnector runs builds in a separate process, so we must explicitly pass init scripts.
         // This is required for Nebula tests, which rely on init scripts for test setup.
@@ -92,5 +103,9 @@ public abstract class DryRunTask extends DefaultTask {
         }
 
         return argumentsBuilder.build();
+    }
+
+    public final Set<String> dryRunResult() {
+        return new TaskListFile(getDryRunResult().getAsFile().get().toPath()).loadTasks();
     }
 }

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/DryRunTask.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/DryRunTask.java
@@ -39,7 +39,7 @@ import org.gradle.tooling.ProjectConnection;
 public abstract class DryRunTask extends DefaultTask {
 
     @Input
-    public abstract SetProperty<String> getTasks();
+    public abstract SetProperty<String> getTasksToDryRun();
 
     @Input
     public abstract ListProperty<String> getArguments();
@@ -56,7 +56,7 @@ public abstract class DryRunTask extends DefaultTask {
 
     @TaskAction
     public final void dryRun() {
-        Set<String> tasks = getTasks().get();
+        Set<String> tasks = getTasksToDryRun().get();
 
         if (tasks.isEmpty()) {
             getLogger().info("No tasks to dry-run");

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/DryRunTask.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/DryRunTask.java
@@ -1,0 +1,96 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.configcache.incremental;
+
+import com.google.common.collect.ImmutableList;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.tooling.GradleConnectionException;
+import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ProjectConnection;
+
+public abstract class DryRunTask extends DefaultTask {
+
+    @Input
+    public abstract SetProperty<String> getTasks();
+
+    @Input
+    @org.gradle.api.tasks.Optional
+    public abstract Property<String> getInitScript();
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
+
+    public final Set<String> dryRun(List<String> args) throws GradleConnectionException {
+        Set<String> tasks = getTasks().get();
+
+        if (tasks.isEmpty()) {
+            getLogger().info("No tasks to dry-run");
+            return new TreeSet<>();
+        }
+
+        getLogger().info("Dry-running {} tasks", tasks.size());
+
+        GradleConnector connector = GradleConnector.newConnector()
+                .forProjectDirectory(getProjectLayout().getProjectDirectory().getAsFile());
+
+        try (ProjectConnection connection = connector.connect()) {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+            connection
+                    .newBuild()
+                    .withArguments(buildArguments(args))
+                    .forTasks(tasks.toArray(new String[0]))
+                    .setStandardOutput(outputStream)
+                    .setStandardError(outputStream)
+                    .run();
+
+            getLogger().info("All {} tasks passed dry-ran successfully", tasks.size());
+
+            return Pattern.compile("(:[\\w:-]+)\\s+SKIPPED")
+                    .matcher(outputStream.toString(StandardCharsets.UTF_8))
+                    .results()
+                    .map(m -> m.group(1))
+                    .collect(Collectors.toCollection(TreeSet::new));
+        }
+    }
+
+    private ImmutableList<String> buildArguments(List<String> args) {
+        ImmutableList.Builder<String> argumentsBuilder = ImmutableList.builder();
+        argumentsBuilder.add("--dry-run");
+        argumentsBuilder.addAll(args);
+
+        // GradleConnector runs builds in a separate process, so we must explicitly pass init scripts.
+        // This is required for Nebula tests, which rely on init scripts for test setup.
+        if (getInitScript().isPresent() && !getInitScript().get().isBlank()) {
+            argumentsBuilder.add("--init-script=" + getInitScript().get());
+        }
+
+        return argumentsBuilder.build();
+    }
+}

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -76,7 +76,7 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
 
         TaskProvider<CheckConfigurationCacheLockTask> checkLock = project.getTasks()
                 .register("checkConfigurationCacheLock", CheckConfigurationCacheLockTask.class, task -> {
-                    task.getTasks().set(new TaskListFile(targetTasksPath).loadTasks());
+                    task.getTasksToDryRun().set(new TaskListFile(targetTasksPath).loadTasks());
                     task.getArguments().set(List.of("--quiet", "-Pconfiguration-cache-incompatible-for-all-tasks"));
                     task.getDryRunResult()
                             .set(task.getTemporaryDir()
@@ -84,7 +84,7 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
                                     .resolve("dryRunNoConfigurationCache")
                                     .toFile());
 
-                    task.getLock().from(lockFilePath.toFile());
+                    task.getLockFile().from(lockFilePath.toFile());
                     task.getShouldFix().set(false);
                 });
 

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -69,13 +69,13 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
         }
 
         TaskListFile lockList = new TaskListFile(lockFilePath);
-        Set<String> enabledTasks = lockList.loadTasks();
+        Set<String> lockListTasks = lockList.loadTasks();
 
         Provider<String> withoutConfigurationCache =
                 project.getProviders().gradleProperty("configuration-cache-compatible-for-all-tasks");
 
         project.getAllprojects().forEach(proj -> proj.getTasks().configureEach(task -> {
-            if (!enabledTasks.contains(task.getPath()) || withoutConfigurationCache.isPresent()) {
+            if (!lockListTasks.contains(task.getPath()) || withoutConfigurationCache.isPresent()) {
                 task.notCompatibleWithConfigurationCache(
                         "Configuration cache is not enabled for this task, as it was not included in %s"
                                 .formatted(TARGET_TASKS_FILE));
@@ -86,7 +86,7 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
                 .register("checkConfigurationCacheLock", CheckConfigurationCacheLockTask.class, task -> {
                     task.getLock().set(lockList);
                     task.getShouldFix().set(false);
-                    task.getTasks().set(enabledTasks);
+                    task.getTasks().set(new TaskListFile(targetTasksPath).loadTasks());
                 });
 
         project.getPluginManager().apply(LifecycleBasePlugin.class);

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -27,7 +27,10 @@ import org.apache.commons.io.FileUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.util.GradleVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +38,8 @@ import org.slf4j.LoggerFactory;
 public abstract class IncrementalConfigurationCachePlugin implements Plugin<Project> {
     private static final Logger log = LoggerFactory.getLogger(IncrementalConfigurationCachePlugin.class);
 
-    private static final Path ALLOW_LIST_FILE = Path.of("gradle/configuration-cache-allowed-tasks");
+    private static final Path TARGET_TASKS_FILE = Path.of("gradle/configuration-cache-allowed-tasks");
+    private static final Path LOCK_FILE = Path.of("gradle/configuration-cache-allowed-tasks.lock");
     private static final GradleVersion MIN_GRADLE_VERSION = GradleVersion.version("8.12.0");
 
     @Inject
@@ -57,22 +61,38 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
                             .formatted(MIN_GRADLE_VERSION));
         }
 
-        Path allowListPath = project.getRootProject().getProjectDir().toPath().resolve(ALLOW_LIST_FILE);
-        if (!Files.exists(allowListPath)) {
+        Path targetTasksPath = project.getRootProject().getProjectDir().toPath().resolve(TARGET_TASKS_FILE);
+        Path lockFilePath = project.getRootProject().getProjectDir().toPath().resolve(LOCK_FILE);
+        if (!Files.exists(targetTasksPath)) {
             throw new RuntimeException(
-                    "Configuration cache allowed tasks file not found at %s".formatted(allowListPath));
+                    "Configuration cache allowed tasks file not found at %s".formatted(targetTasksPath));
         }
 
-        AllowListFile allowList = new AllowListFile(allowListPath);
-        Set<String> enabledTasks = allowList.loadAllowedTasks();
+        TaskListFile lockList = new TaskListFile(lockFilePath);
+        Set<String> enabledTasks = lockList.loadTasks();
+
+        Provider<Boolean> withoutConfigurationCache = project.getProviders()
+                .gradleProperty("DISABLE_CONFIGURATION_CACHE")
+                .map(Boolean::parseBoolean)
+                .orElse(false);
 
         project.getAllprojects().forEach(proj -> proj.getTasks().configureEach(task -> {
-            if (!enabledTasks.contains(task.getPath())) {
+            if (!enabledTasks.contains(task.getPath()) || withoutConfigurationCache.get()) {
                 task.notCompatibleWithConfigurationCache(
                         "Configuration cache is not enabled for this task, as it was not included in %s"
-                                .formatted(ALLOW_LIST_FILE));
+                                .formatted(TARGET_TASKS_FILE));
             }
         }));
+
+        TaskProvider<CheckConfigurationCacheLockTask> checkLock = project.getTasks()
+                .register("checkConfigurationCacheLock", CheckConfigurationCacheLockTask.class, task -> {
+                    task.getLock().set(lockList);
+                    task.getShouldFix().set(false);
+                    task.getTasks().set(new TaskListFile(targetTasksPath).loadTasks());
+                });
+
+        project.getPluginManager().apply(LifecycleBasePlugin.class);
+        project.getTasks().named("check").configure(task -> task.dependsOn(checkLock));
 
         ensureReportsDirIsSymlinkedToCircleArtifacts();
     }

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -81,7 +81,7 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
                     task.getDryRunResult()
                             .set(task.getTemporaryDir()
                                     .toPath()
-                                    .resolve("dry-run-result")
+                                    .resolve("dryRunNoConfigurationCache")
                                     .toFile());
 
                     task.getLock().from(lockFilePath.toFile());

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -71,11 +71,11 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
         TaskListFile lockList = new TaskListFile(lockFilePath);
         Set<String> lockListTasks = lockList.loadTasks();
 
-        Provider<String> withoutConfigurationCache =
+        Provider<String> configurationCacheForAllTasks =
                 project.getProviders().gradleProperty("configuration-cache-compatible-for-all-tasks");
 
         project.getAllprojects().forEach(proj -> proj.getTasks().configureEach(task -> {
-            if (!lockListTasks.contains(task.getPath()) || withoutConfigurationCache.isPresent()) {
+            if (!lockListTasks.contains(task.getPath()) || configurationCacheForAllTasks.isPresent()) {
                 task.notCompatibleWithConfigurationCache(
                         "Configuration cache is not enabled for this task, as it was not included in %s"
                                 .formatted(TARGET_TASKS_FILE));

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -42,6 +42,8 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
     private static final Path TARGET_TASKS_FILE = Path.of("gradle/configuration-cache-allowed-tasks");
     private static final Path LOCK_FILE = Path.of("gradle/configuration-cache-allowed-tasks.lock");
     private static final GradleVersion MIN_GRADLE_VERSION = GradleVersion.version("8.12.0");
+    private static final String CONFIGURATION_CACHE_INCOMPATIBLE_FOR_ALL_TASKS =
+            "configuration-cache-incompatible-for-all-tasks";
 
     @Inject
     protected abstract ProjectLayout getProjectLayout();
@@ -77,7 +79,7 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
         TaskProvider<CheckConfigurationCacheLockTask> checkLock = project.getTasks()
                 .register("checkConfigurationCacheLock", CheckConfigurationCacheLockTask.class, task -> {
                     task.getTasksToDryRun().set(new TaskListFile(targetTasksPath).loadTasks());
-                    task.getArguments().set(List.of("--quiet", "-Pconfiguration-cache-incompatible-for-all-tasks"));
+                    task.getArguments().set(List.of("--quiet", "-P" + CONFIGURATION_CACHE_INCOMPATIBLE_FOR_ALL_TASKS));
                     task.getDryRunResult()
                             .set(task.getTemporaryDir()
                                     .toPath()
@@ -157,7 +159,7 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
 
     private void configureTaskCompatibility(Project project, Set<String> lockListTasks) {
         Provider<String> configurationCacheIncompatibleForAllTasks =
-                project.getProviders().gradleProperty("configuration-cache-incompatible-for-all-tasks");
+                project.getProviders().gradleProperty(CONFIGURATION_CACHE_INCOMPATIBLE_FOR_ALL_TASKS);
 
         project.getAllprojects().forEach(proj -> proj.getTasks().configureEach(task -> {
             if (!lockListTasks.contains(task.getPath()) || configurationCacheIncompatibleForAllTasks.isPresent()) {

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -71,16 +71,7 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
         TaskListFile lockList = new TaskListFile(lockFilePath);
         Set<String> lockListTasks = lockList.loadTasks();
 
-        Provider<String> configurationCacheForAllTasks =
-                project.getProviders().gradleProperty("configuration-cache-compatible-for-all-tasks");
-
-        project.getAllprojects().forEach(proj -> proj.getTasks().configureEach(task -> {
-            if (!lockListTasks.contains(task.getPath()) || configurationCacheForAllTasks.isPresent()) {
-                task.notCompatibleWithConfigurationCache(
-                        "Configuration cache is not enabled for this task, as it was not included in %s"
-                                .formatted(TARGET_TASKS_FILE));
-            }
-        }));
+        configureTaskCompatibility(project, lockListTasks);
 
         TaskProvider<CheckConfigurationCacheLockTask> checkLock = project.getTasks()
                 .register("checkConfigurationCacheLock", CheckConfigurationCacheLockTask.class, task -> {
@@ -154,5 +145,18 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
         } catch (IOException e) {
             throw new UncheckedIOException("Could not create directories to '%s'".formatted(directory), e);
         }
+    }
+
+    private void configureTaskCompatibility(Project project, Set<String> lockListTasks) {
+        Provider<String> configurationCacheIncompatibleForAllTasks =
+                project.getProviders().gradleProperty("configuration-cache-incompatible-for-all-tasks");
+
+        project.getAllprojects().forEach(proj -> proj.getTasks().configureEach(task -> {
+            if (!lockListTasks.contains(task.getPath()) || configurationCacheIncompatibleForAllTasks.isPresent()) {
+                task.notCompatibleWithConfigurationCache(
+                        "Configuration cache is not enabled for this task, as it was not included in %s"
+                                .formatted(TARGET_TASKS_FILE));
+            }
+        }));
     }
 }

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -27,7 +27,6 @@ import org.apache.commons.io.FileUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.ProjectLayout;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -77,7 +76,6 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
                 .register("checkConfigurationCacheLock", CheckConfigurationCacheLockTask.class, task -> {
                     task.getTasksToDryRun().set(new TaskListFile(targetTasksPath).loadTasks());
                     task.getLockFile().from(lockFilePath.toFile());
-                    task.getShouldFix().set(false);
                 });
 
         project.getPluginManager().apply(LifecycleBasePlugin.class);
@@ -148,11 +146,8 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
     }
 
     private void configureTaskCompatibility(Project project, Set<String> lockListTasks) {
-        Provider<String> configurationCacheIncompatibleForAllTasks =
-                project.getProviders().gradleProperty("configuration-cache-incompatible-for-all-tasks");
-
         project.getAllprojects().forEach(proj -> proj.getTasks().configureEach(task -> {
-            if (!lockListTasks.contains(task.getPath()) || configurationCacheIncompatibleForAllTasks.isPresent()) {
+            if (!lockListTasks.contains(task.getPath())) {
                 task.notCompatibleWithConfigurationCache(
                         "Configuration cache is not enabled for this task, as it was not included in %s"
                                 .formatted(TARGET_TASKS_FILE));

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -71,13 +71,11 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
         TaskListFile lockList = new TaskListFile(lockFilePath);
         Set<String> enabledTasks = lockList.loadTasks();
 
-        Provider<Boolean> withoutConfigurationCache = project.getProviders()
-                .gradleProperty("DISABLE_CONFIGURATION_CACHE")
-                .map(Boolean::parseBoolean)
-                .orElse(false);
+        Provider<String> withoutConfigurationCache =
+                project.getProviders().gradleProperty("configuration-cache-compatible-for-all-tasks");
 
         project.getAllprojects().forEach(proj -> proj.getTasks().configureEach(task -> {
-            if (!enabledTasks.contains(task.getPath()) || withoutConfigurationCache.get()) {
+            if (!enabledTasks.contains(task.getPath()) || withoutConfigurationCache.isPresent()) {
                 task.notCompatibleWithConfigurationCache(
                         "Configuration cache is not enabled for this task, as it was not included in %s"
                                 .formatted(TARGET_TASKS_FILE));
@@ -88,7 +86,7 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
                 .register("checkConfigurationCacheLock", CheckConfigurationCacheLockTask.class, task -> {
                     task.getLock().set(lockList);
                     task.getShouldFix().set(false);
-                    task.getTasks().set(new TaskListFile(targetTasksPath).loadTasks());
+                    task.getTasks().set(enabledTasks);
                 });
 
         project.getPluginManager().apply(LifecycleBasePlugin.class);

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
@@ -75,9 +76,16 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
 
         TaskProvider<CheckConfigurationCacheLockTask> checkLock = project.getTasks()
                 .register("checkConfigurationCacheLock", CheckConfigurationCacheLockTask.class, task -> {
-                    task.getLock().set(lockList);
-                    task.getShouldFix().set(false);
                     task.getTasks().set(new TaskListFile(targetTasksPath).loadTasks());
+                    task.getArguments().set(List.of("--quiet", "-Pconfiguration-cache-incompatible-for-all-tasks"));
+                    task.getDryRunResult()
+                            .set(task.getTemporaryDir()
+                                    .toPath()
+                                    .resolve("dry-run-result")
+                                    .toFile());
+
+                    task.getLock().from(lockFilePath.toFile());
+                    task.getShouldFix().set(false);
                 });
 
         project.getPluginManager().apply(LifecycleBasePlugin.class);

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCachePlugin.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
@@ -42,8 +41,6 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
     private static final Path TARGET_TASKS_FILE = Path.of("gradle/configuration-cache-allowed-tasks");
     private static final Path LOCK_FILE = Path.of("gradle/configuration-cache-allowed-tasks.lock");
     private static final GradleVersion MIN_GRADLE_VERSION = GradleVersion.version("8.12.0");
-    private static final String CONFIGURATION_CACHE_INCOMPATIBLE_FOR_ALL_TASKS =
-            "configuration-cache-incompatible-for-all-tasks";
 
     @Inject
     protected abstract ProjectLayout getProjectLayout();
@@ -79,13 +76,6 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
         TaskProvider<CheckConfigurationCacheLockTask> checkLock = project.getTasks()
                 .register("checkConfigurationCacheLock", CheckConfigurationCacheLockTask.class, task -> {
                     task.getTasksToDryRun().set(new TaskListFile(targetTasksPath).loadTasks());
-                    task.getArguments().set(List.of("--quiet", "-P" + CONFIGURATION_CACHE_INCOMPATIBLE_FOR_ALL_TASKS));
-                    task.getDryRunResult()
-                            .set(task.getTemporaryDir()
-                                    .toPath()
-                                    .resolve("dryRunNoConfigurationCache")
-                                    .toFile());
-
                     task.getLockFile().from(lockFilePath.toFile());
                     task.getShouldFix().set(false);
                 });
@@ -159,7 +149,7 @@ public abstract class IncrementalConfigurationCachePlugin implements Plugin<Proj
 
     private void configureTaskCompatibility(Project project, Set<String> lockListTasks) {
         Provider<String> configurationCacheIncompatibleForAllTasks =
-                project.getProviders().gradleProperty(CONFIGURATION_CACHE_INCOMPATIBLE_FOR_ALL_TASKS);
+                project.getProviders().gradleProperty("configuration-cache-incompatible-for-all-tasks");
 
         project.getAllprojects().forEach(proj -> proj.getTasks().configureEach(task -> {
             if (!lockListTasks.contains(task.getPath()) || configurationCacheIncompatibleForAllTasks.isPresent()) {

--- a/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/TaskListFile.java
+++ b/gradle-incremental-configuration-cache/src/main/java/com/palantir/gradle/configcache/incremental/TaskListFile.java
@@ -18,30 +18,41 @@ package com.palantir.gradle.configcache.incremental;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-public final class AllowListFile {
-    private final Path path;
+public record TaskListFile(Path path) {
 
-    public AllowListFile(Path path) {
-        this.path = path;
-
+    public Set<String> loadTasks() {
         if (!Files.exists(path)) {
-            throw new RuntimeException("AllowListFile does not exist at " + path);
+            return new TreeSet<>();
         }
-    }
 
-    public Set<String> loadAllowedTasks() {
         try {
             return Files.readAllLines(path).stream()
                     .map(String::trim)
                     .filter(line -> !line.isEmpty() && !line.startsWith("#"))
-                    .collect(Collectors.toSet());
+                    .collect(Collectors.toCollection(TreeSet::new));
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read configuration cache allowed tasks file: " + path, e);
+        }
+    }
+
+    public static void write(Path path, Set<String> tasks) {
+        try {
+            Files.write(
+                    path,
+                    tasks,
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write to allow list file at " + path, e);
         }
     }
 }

--- a/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockIntegrationSpec.groovy
+++ b/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockIntegrationSpec.groovy
@@ -234,4 +234,39 @@ class CheckConfigurationCacheLockIntegrationSpec extends ConfigurationCacheSpec 
         lockContent.contains(':subproject:classes')
         lockContent.contains(':subproject:compileJava')
     }
+
+    def 'checkConfigurationCacheLock is not up-to-date when lock file changes'() {
+        given:
+        def tasks = '''
+            :classes
+            :compileJava
+            :checkConfigurationCacheLock
+            :processResources
+        '''.stripIndent(true)
+
+        file('gradle/configuration-cache-allowed-tasks') << '''
+            classes
+            checkConfigurationCacheLock
+        '''.stripIndent(true)
+        file('gradle/configuration-cache-allowed-tasks.lock') << tasks
+
+        when:
+        def firstRun = runTasksWithConfigurationCache('checkConfigurationCacheLock')
+
+        then:
+        firstRun.tasks(TaskOutcome.SUCCESS)*.path.contains(':checkConfigurationCacheLock')
+
+        when:
+        def secondRun = runTasksWithConfigurationCache('checkConfigurationCacheLock')
+
+        then:
+        secondRun.tasks(TaskOutcome.UP_TO_DATE)*.path.contains(':checkConfigurationCacheLock')
+
+        when:
+        file('gradle/configuration-cache-allowed-tasks.lock').text = tasks + '\n'
+        def thirdRun = runTasksWithConfigurationCache('checkConfigurationCacheLock')
+
+        then:
+        thirdRun.tasks(TaskOutcome.SUCCESS)*.path.contains(':checkConfigurationCacheLock')
+    }
 }

--- a/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockIntegrationSpec.groovy
+++ b/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockIntegrationSpec.groovy
@@ -1,0 +1,237 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.configcache.incremental
+
+import com.palantir.gradle.plugintesting.ConfigurationCacheSpec
+import org.gradle.testkit.runner.TaskOutcome
+
+class CheckConfigurationCacheLockIntegrationSpec extends ConfigurationCacheSpec {
+    def setup() {
+        // language=gradle
+        buildFile << '''
+            apply plugin: 'com.palantir.incremental-configuration-cache'
+            apply plugin: 'java-library'
+            
+            tasks.named('checkConfigurationCacheLock') {
+                initScript.set(file('.gradle-test-kit/init.gradle').absolutePath)
+            }
+        '''.stripIndent(true)
+
+        file('gradle.properties') << '''
+            org.gradle.configuration-cache=true
+        '''.stripIndent(true)
+    }
+
+    def 'checkConfigurationCacheLock is hooked into check task'() {
+        given:
+        file('gradle/configuration-cache-allowed-tasks') << ''
+
+        when:
+        def result = runTasks('check', '--dry-run')
+
+        then:
+        result.output.contains(':checkConfigurationCacheLock')
+    }
+
+    def 'checkConfigurationCacheLock fails, --fix creates lock file'() {
+        given:
+        file('gradle/configuration-cache-allowed-tasks') << ''
+
+        when:
+        def result = runTasksWithConfigurationCache(true, true,'checkConfigurationCacheLock')
+
+        then:
+        result.output.contains("Run `./gradlew :checkConfigurationCacheLock --fix` to create the lock file.")
+
+        when:
+        runTasks('checkConfigurationCacheLock', '--fix')
+
+        then:
+        new File(projectDir, 'gradle/configuration-cache-allowed-tasks.lock').exists()
+    }
+
+    def 'checkConfigurationCacheLock passes when lock file is correct'() {
+        given:
+        def tasks = '''
+            :classes
+            :compileJava
+            :checkConfigurationCacheLock
+            :processResources
+        '''.stripIndent(true)
+
+        file('gradle/configuration-cache-allowed-tasks') << '''
+            classes
+            checkConfigurationCacheLock
+        '''.stripIndent(true)
+        file('gradle/configuration-cache-allowed-tasks.lock') << tasks
+
+        when:
+        def result = runTasksWithConfigurationCacheAndCheck('checkConfigurationCacheLock')
+
+        then:
+        result.tasks(TaskOutcome.SUCCESS)*.path.contains(':checkConfigurationCacheLock')
+    }
+
+    def 'checkConfigurationCacheLock passes when correct even if configuration cache incompatible task present'() {
+        given:
+        // language=gradle
+        buildFile << '''
+            tasks.register('problematicTask'){
+                def proj = project
+                doLast {
+                    println "Project: ${proj.name}"
+                }
+            }
+        '''.stripIndent(true)
+
+        def tasks = '''
+            :classes
+            :compileJava
+            :checkConfigurationCacheLock
+            :processResources
+            :problematicTask
+        '''.stripIndent(true)
+
+        file('gradle/configuration-cache-allowed-tasks') << '''
+            classes
+            checkConfigurationCacheLock
+            problematicTask
+        '''.stripIndent(true)
+        file('gradle/configuration-cache-allowed-tasks.lock') << tasks
+
+        when:
+        def result = runTasksWithConfigurationCacheAndCheck('checkConfigurationCacheLock', '-Penv=remote')
+
+        then:
+        result.tasks(TaskOutcome.SUCCESS)*.path.contains(':checkConfigurationCacheLock')
+    }
+
+    def 'checkConfigurationCacheLock --fix populates the allow list lock'() {
+        given:
+        def tasks = '''
+            :checkConfigurationCacheLock
+            :classes
+            :compileJava
+            :processResources
+        '''.stripIndent(true)
+
+        file('gradle/configuration-cache-allowed-tasks') << '''
+            classes
+            checkConfigurationCacheLock
+        '''.stripIndent(true)
+        file('gradle/configuration-cache-allowed-tasks.lock') << ''
+
+        when:
+        def result = runTasksWithConfigurationCache(true, false,'checkConfigurationCacheLock', '--fix')
+
+        then:
+        result.tasks(TaskOutcome.SUCCESS)*.path.contains(':checkConfigurationCacheLock')
+        file('gradle/configuration-cache-allowed-tasks.lock').text.trim() == tasks.trim()
+    }
+
+    def 'checkConfigurationCacheLock with bad input fails'() {
+        given:
+        def tasks = '''
+            :fakeTask
+            :checkConfigurationCacheLock
+        '''.stripIndent(true)
+
+        file('gradle/configuration-cache-allowed-tasks') << tasks
+        file('gradle/configuration-cache-allowed-tasks.lock') << tasks
+
+        when:
+        def result = runTasksAndFailWithConfigurationCache('checkConfigurationCacheLock', '--fix')
+
+        then:
+        result.tasks(TaskOutcome.FAILED)*.path.contains(':checkConfigurationCacheLock')
+    }
+
+    def 'fails when lock file has both missing and extra tasks'() {
+        given:
+        file('gradle/configuration-cache-allowed-tasks') << '''
+            classes
+            checkConfigurationCacheLock
+            :jar
+        '''.stripIndent(true)
+
+        // Lock file has different set of tasks
+        file('gradle/configuration-cache-allowed-tasks.lock') << '''
+            :compileJava
+            :compileTestJava
+            :test
+            :checkConfigurationCacheLock
+        '''.stripIndent(true)
+
+        when:
+        def result = runTasksAndFailWithConfigurationCache('checkConfigurationCacheLock')
+
+        then:
+        result.tasks(TaskOutcome.FAILED)*.path.contains(':checkConfigurationCacheLock')
+        result.output.contains('Lock file does not match the tasks that would run')
+        result.output.contains('Total tasks in lock file: 4')
+        result.output.contains('Total tasks that would execute: 5')
+
+        then:
+        runTasksWithConfigurationCache('checkConfigurationCacheLock', '--fix')
+        file('gradle/configuration-cache-allowed-tasks.lock').text.trim() == '''
+            :checkConfigurationCacheLock
+            :classes
+            :compileJava
+            :jar
+            :processResources
+        '''.stripIndent(true).trim()
+    }
+
+    def 'checkConfigurationCacheLock fails when sub-project added then fix works'() {
+        given:
+        def tasks = '''
+            :classes
+            :compileJava
+            :checkConfigurationCacheLock
+            :processResources
+        '''.stripIndent(true)
+
+        file('gradle/configuration-cache-allowed-tasks') << '''
+            classes
+            checkConfigurationCacheLock
+        '''.stripIndent(true)
+        file('gradle/configuration-cache-allowed-tasks.lock') << tasks
+
+        addSubproject("subproject")
+        //language=gradle
+        file('subproject/build.gradle') << '''
+            apply plugin: 'java-library'
+        '''.stripIndent(true)
+
+        when:
+        def result = runTasksAndFailWithConfigurationCache('checkConfigurationCacheLock')
+
+        then:
+        result.tasks(TaskOutcome.FAILED)*.path.contains(':checkConfigurationCacheLock')
+        result.output.contains('Lock file does not match the tasks that would run')
+
+        when:
+        def fixResult = runTasksWithConfigurationCache('checkConfigurationCacheLock', '--fix')
+
+        then:
+        fixResult.tasks(TaskOutcome.SUCCESS)*.path.contains(':checkConfigurationCacheLock')
+        def lockContent = file('gradle/configuration-cache-allowed-tasks.lock').text
+        lockContent.contains(':classes')
+        lockContent.contains(':subproject:classes')
+        lockContent.contains(':subproject:compileJava')
+    }
+}

--- a/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockIntegrationSpec.groovy
+++ b/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/CheckConfigurationCacheLockIntegrationSpec.groovy
@@ -80,7 +80,7 @@ class CheckConfigurationCacheLockIntegrationSpec extends ConfigurationCacheSpec 
         file('gradle/configuration-cache-allowed-tasks.lock') << tasks
 
         when:
-        def result = runTasksWithConfigurationCacheAndCheck('checkConfigurationCacheLock')
+        def result = runTasksWithConfigurationCache('checkConfigurationCacheLock')
 
         then:
         result.tasks(TaskOutcome.SUCCESS)*.path.contains(':checkConfigurationCacheLock')
@@ -114,7 +114,7 @@ class CheckConfigurationCacheLockIntegrationSpec extends ConfigurationCacheSpec 
         file('gradle/configuration-cache-allowed-tasks.lock') << tasks
 
         when:
-        def result = runTasksWithConfigurationCacheAndCheck('checkConfigurationCacheLock', '-Penv=remote')
+        def result = runTasksWithConfigurationCache('checkConfigurationCacheLock')
 
         then:
         result.tasks(TaskOutcome.SUCCESS)*.path.contains(':checkConfigurationCacheLock')

--- a/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheIntegrationSpec.groovy
+++ b/gradle-incremental-configuration-cache/src/test/groovy/com/palantir/gradle/configcache/incremental/IncrementalConfigurationCacheIntegrationSpec.groovy
@@ -17,12 +17,11 @@ package com.palantir.gradle.configcache.incremental
 
 import com.palantir.gradle.plugintesting.ConfigurationCacheSpec
 import groovy.io.FileType
-import nebula.test.IntegrationTestKitSpec
 
 import java.nio.file.Files
 
 
-class IncrementalConfigurationCacheTest extends ConfigurationCacheSpec {
+class IncrementalConfigurationCacheIntegrationSpec extends ConfigurationCacheSpec {
     def setup() {
         // language=gradle
         buildFile << '''
@@ -71,8 +70,9 @@ class IncrementalConfigurationCacheTest extends ConfigurationCacheSpec {
     }
 
 
-    def "tasks in allow list run with config cache"() {
-        file("gradle/configuration-cache-allowed-tasks") << '''
+    def "tasks in lock run with config cache"() {
+        file("gradle/configuration-cache-allowed-tasks")
+        file("gradle/configuration-cache-allowed-tasks.lock") << '''
             :compileJava
             :processResources
             :classes
@@ -82,8 +82,9 @@ class IncrementalConfigurationCacheTest extends ConfigurationCacheSpec {
         runTasksWithConfigurationCacheAndCheck("classes")
     }
 
-    def "tasks not in allow list don't run with config cache"() {
-        file("gradle/configuration-cache-allowed-tasks") << '''
+    def "tasks not in lock don't run with config cache"() {
+        file("gradle/configuration-cache-allowed-tasks")
+        file("gradle/configuration-cache-allowed-tasks.lock") << '''
             :compileJava
             :processResources
         '''.stripIndent(true)

--- a/versions.lock
+++ b/versions.lock
@@ -1,18 +1,34 @@
 # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
 
+com.fasterxml.jackson.core:jackson-annotations:2.19.2 (2 constraints: ff291615)
+
+com.fasterxml.jackson.core:jackson-core:2.19.2 (2 constraints: ff291615)
+
+com.fasterxml.jackson.core:jackson-databind:2.19.2 (1 constraints: 7217b53d)
+
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.19.2 (1 constraints: 3d1b2b47)
+
+com.fasterxml.woodstox:woodstox-core:7.1.1 (1 constraints: 3d174926)
+
 com.google.errorprone:error_prone_annotations:2.36.0 (1 constraints: 4d0a49bf)
 
 com.google.guava:failureaccess:1.0.3 (1 constraints: 160ae3b4)
 
-com.google.guava:guava:33.4.8-jre (2 constraints: e31ee37f)
+com.google.guava:guava:33.4.8-jre (3 constraints: 913b16ca)
 
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
 
 com.google.j2objc:j2objc-annotations:3.0.0 (1 constraints: 150aeab4)
 
+com.palantir.gradle.failure-reports:gradle-failure-reports-common:1.15.0 (1 constraints: ef1c32c2)
+
+com.palantir.gradle.failure-reports:gradle-failure-reports-exceptions:1.15.0 (1 constraints: 3905383b)
+
 com.palantir.gradle.utils:environment-variables:0.18.0 (1 constraints: 3b053b3b)
 
 commons-io:commons-io:2.20.0 (1 constraints: 3605333b)
+
+org.codehaus.woodstox:stax2-api:4.2.2 (2 constraints: 6a278bd2)
 
 org.immutables:value:2.11.3 (1 constraints: 3905353b)
 

--- a/versions.lock
+++ b/versions.lock
@@ -1,26 +1,28 @@
 # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
 
-com.palantir.gradle.utils:environment-variables:0.17.0 (1 constraints: 3a05383b)
+com.google.errorprone:error_prone_annotations:2.36.0 (1 constraints: 4d0a49bf)
+
+com.google.guava:failureaccess:1.0.3 (1 constraints: 160ae3b4)
+
+com.google.guava:guava:33.4.8-jre (2 constraints: e31ee37f)
+
+com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
+
+com.google.j2objc:j2objc-annotations:3.0.0 (1 constraints: 150aeab4)
+
+com.palantir.gradle.utils:environment-variables:0.18.0 (1 constraints: 3b053b3b)
 
 commons-io:commons-io:2.20.0 (1 constraints: 3605333b)
 
 org.immutables:value:2.11.3 (1 constraints: 3905353b)
+
+org.jspecify:jspecify:1.0.0 (1 constraints: 130ae0b4)
 
 
 
 [Test dependencies]
 
 cglib:cglib-nodep:3.2.2 (1 constraints: 490ded24)
-
-com.google.errorprone:error_prone_annotations:2.36.0 (1 constraints: 4d0a49bf)
-
-com.google.guava:failureaccess:1.0.3 (1 constraints: 160ae3b4)
-
-com.google.guava:guava:33.4.8-jre (1 constraints: 3218d16b)
-
-com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
-
-com.google.j2objc:j2objc-annotations:3.0.0 (1 constraints: 150aeab4)
 
 com.netflix.nebula:nebula-test:10.6.2 (2 constraints: d61de72d)
 
@@ -37,8 +39,6 @@ org.codehaus.groovy:groovy:3.0.25 (3 constraints: 14347add)
 org.hamcrest:hamcrest:2.2 (1 constraints: d20cdc04)
 
 org.hamcrest:hamcrest-core:1.3 (1 constraints: cc05fe3f)
-
-org.jspecify:jspecify:1.0.0 (1 constraints: 130ae0b4)
 
 org.junit.jupiter:junit-jupiter:5.13.4 (1 constraints: 7e074077)
 

--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,4 @@
-com.palantir.gradle.utils:* = 0.17.0
+com.palantir.gradle.utils:* = 0.18.0
 com.netflix.nebula:nebula-test = 10.6.2
 junit:junit = 4.13.2
 org.junit.jupiter:* = 5.13.4
@@ -6,3 +6,4 @@ org.junit.vintage:* = 5.13.4
 org.junit.platform:* = 1.13.4
 org.immutables:value = 2.11.3
 commons-io:commons-io = 2.20.0
+com.google.guava:guava = 33.4.8-jre

--- a/versions.props
+++ b/versions.props
@@ -7,3 +7,4 @@ org.junit.platform:* = 1.13.4
 org.immutables:value = 2.11.3
 commons-io:commons-io = 2.20.0
 com.google.guava:guava = 33.4.8-jre
+com.palantir.gradle.failure-reports:gradle-failure-reports-exceptions = 1.15.0


### PR DESCRIPTION
## Before this PR
The incremental configuration cache plugin used a single `configuration-cache-allowed-tasks` file where we had to manually specify exact task paths (like `:compileJava`, `:subproject:compileJava`). This approach was brittle because:
- Adding new subprojects would break the build as their tasks wouldn't be in the allow list
- Renaming tasks or modules required manual updates to the allow list

## After this PR
This PR introduces a two-file system that separates intent from implementation:

1. **`configuration-cache-allowed-tasks`** - Contains high-level task names developers want to enable (e.g., `classes`, `test`)
2. **`configuration-cache-allowed-tasks.lock`** - Auto-generated file containing the exact task paths that will run

### Key improvements:
- **Automatic discovery**: The `checkConfigurationCacheLock` task dry-runs the specified tasks to discover all dependent task paths
- **Validation**: The check task ensures the lock file matches what would actually execute
- **Easy updates**: Run with `--fix` flag to automatically update the lock file when project structure changes

This makes the plugin much more maintainable as the lock file automatically adapts to project structure changes while still maintaining explicit control over which tasks are configuration cache compatible.

==COMMIT_MSG==
Introduce lock file mechanism for incremental configuration cache

Add a lock file system that separates developer intent (allowed tasks) from implementation details (exact task paths). The new `checkConfigurationCacheLock` task automatically discovers and validates all task dependencies, making the plugin resilient to project structure changes.
==COMMIT_MSG==

## Possible downsides?
- Requires running `checkConfigurationCacheLock --fix` when lock file is out of date which adds a bit of mental overhead